### PR TITLE
Removed deprecated dependencies is one which can do it all

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const musicData = require('mp3-duration');
-const wavInfo = require('wav-file-info');
+const musicData = require('music-metadata');
 
 const sources = [
 	'/Users/master/Projects/MunhauzenDocs/Elements/AUDIO_FINAL/Part_1',
@@ -33,25 +32,9 @@ for (let i = 0; i < sources.length; i++) {
 			fs.writeFileSync(`./audio-${suffix}.csv`, rows.join("\r\n"))
 		}
 
-		if (file.indexOf('.wav') !== -1) {
-
-			wavInfo.infoByFilename(dir + '/' + file, (e, metadata) => {
-
-                if (e) throw e
-
-                const duration = Number((metadata.duration * 1000).toFixed(4))
-
-                onComplete(file, duration)
-            });
-
-		} else {
-
-			musicData(dir + '/' + file, (e, duration) => {
-
-                if (e) throw e
-
-                onComplete(file, Number((duration * 1000).toFixed(4)))
-			})
-		}
+		musicData.parseFile(path.join(dir, file)).then(metadata => {
+			const duration = Number((metadata.common.duration * 1000).toFixed(4))
+			onComplete(file, duration)
+		});
 	}
 }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
     "archiver": "^3.0.0",
     "fs-extra": "^8.1.0",
     "md5": "^2.2.1",
-    "mp3-duration": "^1.1.0",
-    "musicmetadata": "^2.0.5",
-    "wav-file-info": "0.0.8",
+    "music-metadata": "^4.5.0",
     "xlsx": "^0.14.3"
   }
 }


### PR DESCRIPTION
I noticed you picked some old dependencies.

I think [music-metadata](https://www.npmjs.com/package/music-metadata) will handle all file types.

If it doesn't work for you, let me know!